### PR TITLE
make gradient height dynamic to canvas height, removed "300"

### DIFF
--- a/lib/AudioSpectrum.js
+++ b/lib/AudioSpectrum.js
@@ -74,7 +74,7 @@ function (_Component) {
 
       var ctx = _this.audioCanvas.getContext('2d');
 
-      var gradient = ctx.createLinearGradient(0, 0, 0, 300);
+      var gradient = ctx.createLinearGradient(0, 0, 0, cheight);
 
       if (_this.props.meterColor.constructor === Array) {
         var stops = _this.props.meterColor;


### PR DESCRIPTION
Gradient was fixed to height 300. If I set the spectrum's height higher than that, it looks uneven, only the top 300 pixel get gradient colors.
I changed it to canvas's height